### PR TITLE
Add offline mock quotes and dev server

### DIFF
--- a/api/yquote.js
+++ b/api/yquote.js
@@ -1,13 +1,24 @@
+import fs from 'fs';
+import path from 'path';
+
+// Load mock quotes to allow offline development
+const mockPath = path.join(process.cwd(), 'data', 'mockQuotes.json');
+const mockData = JSON.parse(fs.readFileSync(mockPath, 'utf-8'));
+
 export default async function handler(req, res) {
-  try{
-    const { symbols='' } = req.query;
-    if(!symbols) return res.status(400).json({error:'symbols is required'});
-    const url = `https://query1.finance.yahoo.com/v7/finance/quote?symbols=${encodeURIComponent(symbols)}`;
+  const { symbols = '' } = req.query;
+  if (!symbols) return res.status(400).json({ error: 'symbols is required' });
+  const url = `https://query1.finance.yahoo.com/v7/finance/quote?symbols=${encodeURIComponent(symbols)}`;
+  try {
     const r = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
     const data = await r.json();
-    res.setHeader('Cache-Control','s-maxage=30, stale-while-revalidate');
+    res.setHeader('Cache-Control', 's-maxage=30, stale-while-revalidate');
     res.status(200).json(data);
-  }catch(e){
-    res.status(500).json({error:'Failed to fetch Yahoo Finance', details: String(e)});
+  } catch (e) {
+    // Fallback to local mock data if Yahoo Finance is unreachable
+    const requested = symbols.split(',').map(s => s.trim());
+    const result = mockData.quoteResponse.result.filter(q => requested.includes(q.symbol));
+    res.status(200).json({ quoteResponse: { result, error: null }, fallback: true });
   }
 }

--- a/data/mockQuotes.json
+++ b/data/mockQuotes.json
@@ -1,0 +1,95 @@
+{
+  "quoteResponse": {
+    "result": [
+      {
+        "symbol": "TSLA",
+        "shortName": "Tesla Inc.",
+        "regularMarketPrice": 700.3,
+        "regularMarketChangePercent": -0.5,
+        "marketCap": 700000000000,
+        "regularMarketDayLow": 695,
+        "regularMarketDayHigh": 710,
+        "regularMarketPreviousClose": 703,
+        "exchange": "NasdaqGS"
+      },
+      {
+        "symbol": "AAPL",
+        "shortName": "Apple Inc.",
+        "regularMarketPrice": 150.25,
+        "regularMarketChangePercent": 1.2,
+        "marketCap": 2000000000000,
+        "regularMarketDayLow": 149.5,
+        "regularMarketDayHigh": 151,
+        "regularMarketPreviousClose": 149,
+        "exchange": "NasdaqGS"
+      },
+      {
+        "symbol": "MSFT",
+        "shortName": "Microsoft Corp.",
+        "regularMarketPrice": 280.1,
+        "regularMarketChangePercent": 0.8,
+        "marketCap": 2100000000000,
+        "regularMarketDayLow": 278,
+        "regularMarketDayHigh": 282,
+        "regularMarketPreviousClose": 278.5,
+        "exchange": "NasdaqGS"
+      },
+      {
+        "symbol": "GOOGL",
+        "shortName": "Alphabet Inc.",
+        "regularMarketPrice": 2700.5,
+        "regularMarketChangePercent": -0.2,
+        "marketCap": 1800000000000,
+        "regularMarketDayLow": 2690,
+        "regularMarketDayHigh": 2725,
+        "regularMarketPreviousClose": 2705,
+        "exchange": "NasdaqGS"
+      },
+      {
+        "symbol": "AMZN",
+        "shortName": "Amazon.com Inc.",
+        "regularMarketPrice": 3300.7,
+        "regularMarketChangePercent": 0.3,
+        "marketCap": 1650000000000,
+        "regularMarketDayLow": 3280,
+        "regularMarketDayHigh": 3335,
+        "regularMarketPreviousClose": 3290,
+        "exchange": "NasdaqGS"
+      },
+      {
+        "symbol": "NVDA",
+        "shortName": "NVIDIA Corp.",
+        "regularMarketPrice": 220.4,
+        "regularMarketChangePercent": -1.1,
+        "marketCap": 550000000000,
+        "regularMarketDayLow": 218,
+        "regularMarketDayHigh": 225,
+        "regularMarketPreviousClose": 222,
+        "exchange": "NasdaqGS"
+      },
+      {
+        "symbol": "^GSPC",
+        "shortName": "S&P 500",
+        "regularMarketPrice": 4300.5,
+        "regularMarketChangePercent": 0.4,
+        "marketCap": null,
+        "regularMarketDayLow": 4280,
+        "regularMarketDayHigh": 4320,
+        "regularMarketPreviousClose": 4283,
+        "exchange": "INDEX"
+      },
+      {
+        "symbol": "^IXIC",
+        "shortName": "NASDAQ Composite",
+        "regularMarketPrice": 14000.8,
+        "regularMarketChangePercent": -0.6,
+        "marketCap": null,
+        "regularMarketDayLow": 13950,
+        "regularMarketDayHigh": 14120,
+        "regularMarketPreviousClose": 14085,
+        "exchange": "INDEX"
+      }
+    ],
+    "error": null
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "financial-tracker",
+  "version": "1.0.0",
+  "type": "module"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,39 @@
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+import url from 'url';
+import handler from './api/yquote.js';
+
+const server = http.createServer((req, res) => {
+  const parsed = url.parse(req.url, true);
+  if (parsed.pathname === '/api/yquote') {
+    req.query = parsed.query;
+    res.status = code => { res.statusCode = code; return res; };
+    res.json = obj => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify(obj));
+    };
+    handler(req, res);
+    return;
+  }
+
+  let filePath = path.join(process.cwd(), parsed.pathname === '/' ? '/index.html' : parsed.pathname);
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.statusCode = 404;
+      res.end('Not found');
+      return;
+    }
+    if (filePath.endsWith('.html')) res.setHeader('Content-Type', 'text/html');
+    else if (filePath.endsWith('.js')) res.setHeader('Content-Type', 'text/javascript');
+    else if (filePath.endsWith('.css')) res.setHeader('Content-Type', 'text/css');
+    else if (filePath.endsWith('.json')) res.setHeader('Content-Type', 'application/json');
+    res.statusCode = 200;
+    res.end(data);
+  });
+});
+
+const port = 3000;
+server.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- provide Yahoo Finance fallback data for offline development
- add minimal Node server to serve static files and API route

## Testing
- `node server.js`
- `curl -s http://localhost:3000/api/yquote?symbols=AAPL,TSLA`
- `curl -s 'http://localhost:3000/api/yquote?symbols=%5EGSPC,%5EIXIC'`
- `node -e "fetch('http://localhost:3000/api/yquote?symbols=TSLA').then(r=>r.json()).then(d=>console.log(d.quoteResponse.result[0].regularMarketPrice))"`

------
https://chatgpt.com/codex/tasks/task_e_68a80add3184832994169b7caa010706